### PR TITLE
BF-11624 boost download location

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -28,16 +28,33 @@ task createNativeDepsDirectories {
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     // Use ZIP version as it's faster this way to selectively extract some parts of the archive
-    src 'https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.zip'
+    src 'https://registry.yarnpkg.com/boost-react-native-bundle/-/boost-react-native-bundle-1.57.0.tgz'
     // alternative
     // src 'http://mirror.nienbo.com/boost/boost_1_57_0.zip'
     onlyIfNewer true
     overwrite false
-    dest new File(downloadsDir, 'boost_1_57_0.zip')
+    dest new File(downloadsDir, 'boost-react-native-bundle-1.57.0.tgz')
 }
 
-task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
-    from boostPath ? boostPath : zipTree(downloadBoost.dest)
+task unpackBoost(dependsOn: downloadBoost, type: Copy) {
+    from tarTree(resources.gzip(downloadBoost.dest))
+    include 'package/boost_1_57_0/boost/**/*.hpp'
+    into "$thirdPartyNdkDir/boost"
+    // npm packages are unpacked into folder "package" that we want to strip
+    eachFile { FileCopyDetails fcp ->
+        if (fcp.relativePath.pathString.startsWith("package")) {
+            // remap the file to the root
+            def segments = fcp.relativePath.segments
+            def pathsegments = segments[1..-1] as String[]
+            fcp.relativePath = new RelativePath(!fcp.file.isDirectory(), pathsegments)
+        } else {
+            fcp.exclude()
+        }
+    }
+}
+
+task prepareBoost(dependsOn: boostPath ? [] : [unpackBoost], type: Copy) {
+    from boostPath ?: []
     from 'src/main/jni/third-party/boost/Android.mk'
     include 'boost_1_57_0/boost/**/*.hpp', 'Android.mk'
     into "$thirdPartyNdkDir/boost"


### PR DESCRIPTION
https://bloomfire.atlassian.net/browse/BF-11624

since the old boost location was giving ssl errors, facebook has moved it to
ashared repo. for more info, see:
https://github.com/facebook/react-native/pull/11469